### PR TITLE
Missing 'env' directory

### DIFF
--- a/docs/tutorials/tutorial-0.rst
+++ b/docs/tutorials/tutorial-0.rst
@@ -29,6 +29,7 @@ Let's start by creating a ``tutorial0`` directory in the tutorial directory alon
 So that your directory structure looks like::
 
     tutorial
+    ├── env
     ├── tutorial0
     └── voc
 


### PR DESCRIPTION
The tree example does not include the 'env' folder. 
... Now it does.
